### PR TITLE
Add prefer lodash methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+* Add plugin for preferring lodash/fp methods over native
+
 # 1.0.2
 
 * Fix main not pointing correctly at the right source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-smartprocure",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ESLint Plugins made for SmartProcure",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "type": "git",
     "url": "git+https://github.com/smartprocure/eslint-plugin-smartprocure.git"
   },
-  "keywords": ["eslint", "eslint-plugin"],
+  "keywords": [
+    "eslint",
+    "eslint-plugin"
+  ],
   "author": "SmartProcure",
   "license": "MIT",
   "bugs": {
@@ -28,8 +31,7 @@
     "semi": false,
     "singleQuote": true
   },
-  "homepage":
-    "https://github.com/smartprocure/eslint-plugin-smartprocure#readme",
+  "homepage": "https://github.com/smartprocure/eslint-plugin-smartprocure#readme",
   "devDependencies": {
     "duti": "^0.9.5",
     "eslint": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint-fix": "npm run lint -- --fix",
     "lint-ci": "npm run lint -- -o lint-results.json -f json",
     "test": "jest src",
+    "test-watch": "npm test -- --watch",
     "test-ci": "npm test -- --outputFile=test-results.json --json",
     "fmt": "prettier --write src/**/*.*",
     "duti:fix": "npm run lint-fix && npm run fmt",
@@ -17,10 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/smartprocure/eslint-plugin-smartprocure.git"
   },
-  "keywords": [
-    "eslint",
-    "eslint-plugin"
-  ],
+  "keywords": ["eslint", "eslint-plugin"],
   "author": "SmartProcure",
   "license": "MIT",
   "bugs": {
@@ -30,7 +28,8 @@
     "semi": false,
     "singleQuote": true
   },
-  "homepage": "https://github.com/smartprocure/eslint-plugin-smartprocure#readme",
+  "homepage":
+    "https://github.com/smartprocure/eslint-plugin-smartprocure#readme",
   "devDependencies": {
     "duti": "^0.9.5",
     "eslint": "^4.12.1",

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -3,9 +3,6 @@ let _ = require('lodash/fp')
 let bannedMethods = ['map', 'reduce', 'concat', 'includes']
 
 module.exports = {
-  meta: {
-    fixable: 'code'
-  },
   create: ctx => ({
     MemberExpression(node) {
       let method = _.get('property.name', node)

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -1,6 +1,23 @@
 let _ = require('lodash/fp')
 
-let bannedMethods = ['map', 'reduce', 'concat', 'includes']
+let bannedMethods = [
+  'map',
+  'reduce',
+  'concat',
+  'includes',
+  'sort',
+  'every',
+  'filter',
+  'find',
+  'forEach',
+  'indexOf',
+  'join',
+  'reduceRight',
+  'reverse',
+  'slice',
+  'some',
+  'sort'
+]
 
 module.exports = {
   create: ctx => ({

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -85,18 +85,12 @@ module.exports = {
           fix(fixer) {
             let methodArgs = node.parent.arguments
             let wontFix = fixer.insertTextAfter(node, '')
-            if (methodArgs.length > bannedMethods[method].arity) {
-              return wontFix
-            }
             let firstMethodArg = methodArgs[0]
             let firstMethodArgType = firstMethodArg.type
             if (
-              firstMethodArgType !== 'FunctionExpression' &&
-              firstMethodArgType !== 'ArrowFunctionExpression'
-            ) {
-              return wontFix
-            }
-            if (
+              methodArgs.length > bannedMethods[method].arity ||
+              (firstMethodArgType !== 'FunctionExpression' &&
+                firstMethodArgType !== 'ArrowFunctionExpression') ||
               firstMethodArg.params.length > bannedMethods[method].iteratorArity
             ) {
               return wontFix

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -84,8 +84,9 @@ module.exports = {
           message: `Use the lodash alternative for ${method}`,
           fix(fixer) {
             let methodArgs = node.parent.arguments
+            let wontFix = fixer.insertTextAfter(node, '')
             if (methodArgs.length > bannedMethods[method].arity) {
-              return fixer.insertTextAfter(node, '')
+              return wontFix
             }
             let firstMethodArg = methodArgs[0]
             let firstMethodArgType = firstMethodArg.type
@@ -93,12 +94,12 @@ module.exports = {
               firstMethodArgType !== 'FunctionExpression' &&
               firstMethodArgType !== 'ArrowFunctionExpression'
             ) {
-              return fixer.insertTextAfter(node, '')
+              return wontFix
             }
             if (
               firstMethodArg.params.length > bannedMethods[method].iteratorArity
             ) {
-              return fixer.insertTextAfter(node, '')
+              return wontFix
             }
             let parent = node.parent
             return fixer.replaceText(

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -16,7 +16,8 @@ let bannedMethods = [
   'reverse',
   'slice',
   'some',
-  'sort'
+  'sort',
+  'lastIndexOf'
 ]
 
 module.exports = {

--- a/src/prefer-lodash-fp-method.js
+++ b/src/prefer-lodash-fp-method.js
@@ -1,0 +1,23 @@
+let _ = require('lodash/fp')
+
+let bannedMethods = ['map', 'reduce', 'concat', 'includes']
+
+module.exports = {
+  meta: {
+    fixable: 'code'
+  },
+  create: ctx => ({
+    MemberExpression(node) {
+      let method = _.get('property.name', node)
+      let fromLodash =
+        _.get('object.type', node) === 'Identifier' &&
+        _.get('object.name', node) === '_'
+      if (!fromLodash && _.includes(method, bannedMethods)) {
+        ctx.report({
+          node,
+          message: `Use the lodash alternative for ${method}`
+        })
+      }
+    }
+  })
+}

--- a/src/prefer-lodash-fp-method.spec.js
+++ b/src/prefer-lodash-fp-method.spec.js
@@ -40,7 +40,9 @@ let validCode = [
   `let _ = require('lodash/fp');
   _.some(x, y)`,
   `let _ = require('lodash/fp');
-  _.sort(x, y)`
+  _.sort(x, y)`,
+  `let _ = require('lodash/fp');
+  _.lastIndexOf(x, y)`
 ]
 
 let invalidCode = [
@@ -57,7 +59,8 @@ let invalidCode = [
   { code: `y.reverse(x)`, method: 'reverse' },
   { code: `y.slice(x)`, method: 'slice' },
   { code: `y.some(x)`, method: 'some' },
-  { code: `y.sort(x)`, method: 'sort' }
+  { code: `y.sort(x)`, method: 'sort' },
+  { code: `y.lastIndexOf(x)`, method: 'lastIndexOf' }
 ]
 
 ruleTester.run('prefer-lodash-fp-methods', rule, {

--- a/src/prefer-lodash-fp-method.spec.js
+++ b/src/prefer-lodash-fp-method.spec.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 
 let { RuleTester } = require('eslint')
-let rule = require('./no-lodash-constant')
+let _ = require('lodash/fp')
+let rule = require('./prefer-lodash-fp-method')
 
 RuleTester.setDefaultConfig({
   parserOptions: {
@@ -12,11 +13,9 @@ RuleTester.setDefaultConfig({
 let ruleTester = new RuleTester()
 
 let validCode = [
-  `let _ = require('lodash/fp')
+  `let _ = require('lodash/fp');
   _.map(x => x, [])`,
-  `let bob = require('lodash/fp')
-  bob.map(x => x, [])`,
-  `let _ = require('lodash/fp')
+  `let _ = require('lodash/fp');
   _.includes('cheese', ['cheese'])`
 ]
 
@@ -32,13 +31,16 @@ let invalidCode = [
 ]
 
 ruleTester.run('prefer-lodash-fp-methods', rule, {
-  valid: validCode.map(code => ({ code })),
-  invalid: invalidCode.map(({ code, method }) => ({
-    code,
-    errors: [
-      {
-        message: `Use _.${method}`
-      }
-    ]
-  }))
+  valid: _.map(code => ({ code }), validCode),
+  invalid: _.map(
+    ({ code, method }) => ({
+      code,
+      errors: [
+        {
+          message: `Use the lodash alternative for ${method}`
+        }
+      ]
+    }),
+    invalidCode
+  )
 })

--- a/src/prefer-lodash-fp-method.spec.js
+++ b/src/prefer-lodash-fp-method.spec.js
@@ -46,33 +46,69 @@ let validCode = [
 ]
 
 let invalidCode = [
-  { code: `y.map(x)`, method: 'map' },
-  { code: `y.includes(x)`, method: 'includes' },
-  { code: `y.sort(x)`, method: 'sort' },
-  { code: `y.every(x)`, method: 'every' },
-  { code: `y.filter(x)`, method: 'filter' },
-  { code: `y.find(x)`, method: 'find' },
-  { code: `y.forEach(x)`, method: 'forEach' },
-  { code: `y.indexOf(x)`, method: 'indexOf' },
-  { code: `y.join(x)`, method: 'join' },
-  { code: `y.reduceRight(x)`, method: 'reduceRight' },
-  { code: `y.reverse(x)`, method: 'reverse' },
-  { code: `y.slice(x)`, method: 'slice' },
-  { code: `y.some(x)`, method: 'some' },
-  { code: `y.sort(x)`, method: 'sort' },
-  { code: `y.lastIndexOf(x)`, method: 'lastIndexOf' }
+  { input: `y.map(x)`, method: 'map', output: `y.map(x)` },
+  { input: `y.includes(x)`, method: 'includes', output: `y.includes(x)` },
+  { input: `y.sort(x)`, method: 'sort', output: `y.sort(x)` },
+  { input: `y.every(x)`, method: 'every', output: `y.every(x)` },
+  { input: `y.filter(x)`, method: 'filter', output: `y.filter(x)` },
+  { input: `y.find(x)`, method: 'find', output: `y.find(x)` },
+  { input: `y.forEach(x)`, method: 'forEach', output: `y.forEach(x)` },
+  { input: `y.indexOf(x)`, method: 'indexOf', output: `y.indexOf(x)` },
+  { input: `y.join(x)`, method: 'join', output: `y.join(x)` },
+  {
+    input: `y.reduceRight(x)`,
+    method: 'reduceRight',
+    output: `y.reduceRight(x)`
+  },
+  { input: `y.reverse(x)`, method: 'reverse', output: `y.reverse(x)` },
+  { input: `y.slice(x)`, method: 'slice', output: `y.slice(x)` },
+  { input: `y.some(x)`, method: 'some', output: `y.some(x)` },
+  { input: `y.sort(x)`, method: 'sort', output: `y.sort(x)` },
+  {
+    input: `y.lastIndexOf(x)`,
+    method: 'lastIndexOf',
+    output: `y.lastIndexOf(x)`
+  },
+  { input: `y.map(x => 1)`, method: 'map', output: `_.map(x => 1, y)` },
+  { input: `y.map((x, y) => 1)`, method: 'map', output: `y.map((x, y) => 1)` },
+  {
+    input: `y.map(function(x) { return 1 })`,
+    method: 'map',
+    output: `_.map(function(x) { return 1 }, y)`
+  },
+  {
+    input: `y.map(function(x, y) { return 1 })`,
+    method: 'map',
+    output: `y.map(function(x, y) { return 1 })`
+  },
+  {
+    input: `y.reduce(function(x, i) { return x + i }, z)`,
+    method: 'reduce',
+    output: `_.reduce(function(x, i) { return x + i }, z, y)`
+  },
+  {
+    input: `[].reduce(function(x, i) { return x + i }, z)`,
+    method: 'reduce',
+    output: `_.reduce(function(x, i) { return x + i }, z, [])`
+  },
+  {
+    input: `[].some(x => x === y)`,
+    method: 'some',
+    output: `_.some(x => x === y, [])`
+  }
 ]
 
 ruleTester.run('prefer-lodash-fp-methods', rule, {
   valid: _.map(code => ({ code }), validCode),
   invalid: _.map(
-    ({ code, method }) => ({
-      code,
+    ({ input, method, output }) => ({
+      code: input,
       errors: [
         {
           message: `Use the lodash alternative for ${method}`
         }
-      ]
+      ],
+      output
     }),
     invalidCode
   )

--- a/src/prefer-lodash-fp-method.spec.js
+++ b/src/prefer-lodash-fp-method.spec.js
@@ -14,20 +14,50 @@ let ruleTester = new RuleTester()
 
 let validCode = [
   `let _ = require('lodash/fp');
-  _.map(x => x, [])`,
+  _.map(x, y)`,
   `let _ = require('lodash/fp');
-  _.includes('cheese', ['cheese'])`
+  _.includes(x, y)`,
+  `let _ = require('lodash/fp');
+  _.sort(x, y)`,
+  `let _ = require('lodash/fp');
+  _.every(x, y)`,
+  `let _ = require('lodash/fp');
+  _.filter(x, y)`,
+  `let _ = require('lodash/fp');
+  _.find(x, y)`,
+  `let _ = require('lodash/fp');
+  _.forEach(x, y)`,
+  `let _ = require('lodash/fp');
+  _.indexOf(x, y)`,
+  `let _ = require('lodash/fp');
+  _.join(x, y)`,
+  `let _ = require('lodash/fp');
+  _.reduceRight(x, y)`,
+  `let _ = require('lodash/fp');
+  _.reverse(x, y)`,
+  `let _ = require('lodash/fp');
+  _.slice(x, y)`,
+  `let _ = require('lodash/fp');
+  _.some(x, y)`,
+  `let _ = require('lodash/fp');
+  _.sort(x, y)`
 ]
 
 let invalidCode = [
-  {
-    code: `[].map(x => x)`,
-    method: 'map'
-  },
-  {
-    code: `['cheese'].includes('cheese')`,
-    method: 'includes'
-  }
+  { code: `y.map(x)`, method: 'map' },
+  { code: `y.includes(x)`, method: 'includes' },
+  { code: `y.sort(x)`, method: 'sort' },
+  { code: `y.every(x)`, method: 'every' },
+  { code: `y.filter(x)`, method: 'filter' },
+  { code: `y.find(x)`, method: 'find' },
+  { code: `y.forEach(x)`, method: 'forEach' },
+  { code: `y.indexOf(x)`, method: 'indexOf' },
+  { code: `y.join(x)`, method: 'join' },
+  { code: `y.reduceRight(x)`, method: 'reduceRight' },
+  { code: `y.reverse(x)`, method: 'reverse' },
+  { code: `y.slice(x)`, method: 'slice' },
+  { code: `y.some(x)`, method: 'some' },
+  { code: `y.sort(x)`, method: 'sort' }
 ]
 
 ruleTester.run('prefer-lodash-fp-methods', rule, {

--- a/src/prefer-lodash-fp-method.spec.js
+++ b/src/prefer-lodash-fp-method.spec.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+
+let { RuleTester } = require('eslint')
+let rule = require('./no-lodash-constant')
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
+
+let ruleTester = new RuleTester()
+
+let validCode = [
+  `let _ = require('lodash/fp')
+  _.map(x => x, [])`,
+  `let bob = require('lodash/fp')
+  bob.map(x => x, [])`,
+  `let _ = require('lodash/fp')
+  _.includes('cheese', ['cheese'])`
+]
+
+let invalidCode = [
+  {
+    code: `[].map(x => x)`,
+    method: 'map'
+  },
+  {
+    code: `['cheese'].includes('cheese')`,
+    method: 'includes'
+  }
+]
+
+ruleTester.run('prefer-lodash-fp-methods', rule, {
+  valid: validCode.map(code => ({ code })),
+  invalid: invalidCode.map(({ code, method }) => ({
+    code,
+    errors: [
+      {
+        message: `Use _.${method}`
+      }
+    ]
+  }))
+})


### PR DESCRIPTION
Fixes smartprocure/marketplace#2112

This adds support for warning about the following methods that aren't used in a lodashy-way:

- `map`
- `reduce`
- `concat`
- `includes`
- `sort`
- `every`
- `filter`
- `find`
- `forEach`
- `indexOf`
- `join`
- `reduceRight`
- `reverse`
- `slice`
- `some`
- `lastIndexOf`

Also, please take a look at the tests to see what is considered "valid" and "invalid" code for this rule. If there any changes we should make please let me know :D